### PR TITLE
ciの中にビルドの設定を入れる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
             key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
             restore-keys: |
               ${{ runner.os }}-gradle-
-
+        - name: Build with Gradle
+          run: ./gradlew build
+       
     lint:
     ktlint:
     unit_test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,24 @@ on:
 
 jobs:
     build:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Set up JDK 17
+          uses: actions/setup-java@v2
+          with:
+            distribution: 'zulu'
+            java-version: 17
+        - name: use Cache
+          uses: actions/cache@v2
+          with:
+            path: ~/.gradle/caches
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+
     lint:
     ktlint:
     unit_test:
     instrumented_test:
-        

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
             distribution: 'zulu'
             java-version: 17
         - name: use Cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.gradle/caches
             key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
         - name: Build with Gradle
           run: ./gradlew build
        
-    lint:
-    ktlint:
-    unit_test:
-    instrumented_test:
+    # この下の部分でエラーになったので、一時的にコメントアウトしておく
+    # lint:
+    # ktlint:
+    # unit_test:
+    # instrumented_test:

--- a/README.md
+++ b/README.md
@@ -121,3 +121,7 @@ testフォルダやandroidtestフォルダ、resフォルダはrootと同じ階�
 │   └── NetworkModule.kt
 └── MainActivity.kt
 ```
+
+
+## 環境
+- Gradle JDK: 17.0.7

--- a/coding_guideline.md
+++ b/coding_guideline.md
@@ -12,5 +12,5 @@
 - トピックブランチはfeat/[変更を端的に表した短文]という命名にする
   - 例えば、認証機能追加ならfeat/add-authentication
 - プルリクエストのマージ時に、topic→developはsquashし、develop→mainはrebaseする
-
+  - 開発初期の0→1はPRの粒度が大きくなる。しかし、無理やり小さくするのは難しいので、topicブランチの子ブランチを作成して、子ブランチからtopicブランチ本体へのマージの時にsquashすることにした。
 


### PR DESCRIPTION
# やったこと
- ビルドに使うjdkのバージョンを決定(17)
- ワークフロー内で共通利用するアクションのバージョンを決定(checkout→4, jdk setup→2, cache→2)
- ビルド用のジョブを作成
