### PR TITLE
instrumental unit testをciのジョブに追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,21 @@ jobs:
         - name: Run Unit Test
           run: ./gradlew test
 
-    # この下の部分でエラーになったので、一時的にコメントアウトしておく
-    # instrumented_test:
+    instrumented_unit_test:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Enable KVM
+          run: |
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
+  
+        - name: Run Android Emulator
+          uses: ReactiveCircus/android-emulator-runner@v2.33.0
+          with:
+            api-level: 29
+            target: google_apis
+            arch: x86_64
+            script: ./gradlew connectedCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: ci
 on:
     pull_request:
         types: [opened, synchronize, reopened]
-    # TODO: デバッグ用なので、developブランチに入れる前に消す
-    push:
-        branches:
-            - feat/ci*
 
 jobs:
     build:


### PR DESCRIPTION
# やったこと
- instrumented unit testをciの中で実行するようにする
  - actionsの実行環境でandroid emulator作成
  - 上記emultor上でinstrumental unit testを実行
  - 