### PR TITLE
Authentication周りのテストを追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,8 @@ dependencies {
 
     // unit test
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito:mockito-core:5.11.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
     // hiltのunit test
     testImplementation("com.google.dagger:hilt-android-testing:$hiltVersion")
     kspTest("com.google.dagger:hilt-android-compiler:$hiltVersion")
@@ -102,6 +104,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("org.mockito:mockito-core:5.11.0")
     // hiltのinstrumented test
     androidTestImplementation("com.google.dagger:hilt-android-testing:$hiltVersion")
     kspAndroidTest("com.google.dagger:hilt-android-compiler:$hiltVersion")

--- a/app/src/androidTest/java/com/shunk0616/gpshealthconnect/ui/authentication/AuthenticationScreenTest.kt
+++ b/app/src/androidTest/java/com/shunk0616/gpshealthconnect/ui/authentication/AuthenticationScreenTest.kt
@@ -1,0 +1,105 @@
+package com.shunk0616.gpshealthconnect.ui.authentication
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+
+class AuthenticationScreenTest {
+
+    private val errorMessageText = "エラーが発生しました"
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun authenticationScreen_displaysSignInButton() {
+        // Given
+        val onSignInClick: () -> Unit = {}
+        val onShowSnackbar: suspend (String, String?) -> Boolean = { _, _ -> true }
+        val errorMessage: String? = null
+        
+        // When
+        composeTestRule.setContent {
+            AuthenticationScreen(
+                onSignInClick = onSignInClick,
+                onShowSnackbar = onShowSnackbar,
+                errorMessage = errorMessage
+            )
+        }
+        
+        // Then
+        composeTestRule.onNodeWithText("このスマホで始める").assertIsDisplayed()
+    }
+
+    @Test
+    fun signInButton_clickTriggersLoginAndNavigation() {
+        // Given
+        var signInClicked = false
+        val onSignInClick: () -> Unit = { signInClicked = true }
+        val onShowSnackbar: suspend (String, String?) -> Boolean = { _, _ -> true }
+        val errorMessage: String? = null
+        
+        // When
+        composeTestRule.setContent {
+            AuthenticationScreen(
+                onSignInClick = onSignInClick,
+                onShowSnackbar = onShowSnackbar,
+                errorMessage = errorMessage
+            )
+        }
+        
+        // Click the sign in button
+        composeTestRule.onNodeWithText("このスマホで始める").performClick()
+        
+        // Then
+        assert(signInClicked) { "Sign in button click was not handled" }
+    }
+
+    @Test
+    fun authenticationScreen_displaysErrorMessage() {
+        // Given
+        val onSignInClick: () -> Unit = {}
+        val onShowSnackbar: suspend (String, String?) -> Boolean = { _, _ -> true }
+        val errorMessage: String = errorMessageText
+        
+        // When
+        composeTestRule.setContent {
+            AuthenticationScreen(
+                onSignInClick = onSignInClick,
+                onShowSnackbar = onShowSnackbar,
+                errorMessage = errorMessage
+            )
+        }
+        
+        // Then
+        composeTestRule.onNodeWithText(errorMessageText).assertIsDisplayed()
+    }
+
+    @Test
+    fun onShowSnackbar_isCalledWhenErrorOccurs() {
+        // Given
+        var snackbarShown = false
+        val onSignInClick: () -> Unit = {}
+        val onShowSnackbar: suspend (String, String?) -> Boolean = { message, _ ->
+            snackbarShown = message == errorMessageText
+            true
+        }
+        
+        // When
+        composeTestRule.setContent {
+            AuthenticationScreen(
+                onSignInClick = onSignInClick,
+                onShowSnackbar = onShowSnackbar,
+                errorMessage = errorMessageText
+            )
+        }
+        
+        // Then
+        assert(snackbarShown) { "Snackbar was not shown with error message" }
+    }
+}

--- a/app/src/test/java/com/shunk0616/gpshealthconnect/data/repository/AccountRepositoryTest.kt
+++ b/app/src/test/java/com/shunk0616/gpshealthconnect/data/repository/AccountRepositoryTest.kt
@@ -1,0 +1,62 @@
+package com.shunk0616.gpshealthconnect.data.repository
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.shunk0616.gpshealthconnect.data.repository.impl.AccountRepositoryImpl
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.mockito.junit.MockitoJUnitRunner
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class AccountRepositoryTest {
+
+    @Mock
+    private lateinit var mockAuth: FirebaseAuth
+
+    @Mock
+    private lateinit var mockAuthTask: Task<com.google.firebase.auth.AuthResult>
+
+    @Mock
+    private lateinit var mockUser: FirebaseUser
+
+    private lateinit var repository: AccountRepositoryImpl
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    @Before
+    fun setup() {
+        repository = AccountRepositoryImpl(mockAuth)
+    }
+
+    @Test
+    fun isAuthorized_returnsFalse() {
+        // 最初は未認証
+        assertFalse(repository.isAuthorized)
+    }
+
+    @Test
+    fun login_callsSignInAnonymously() = runTest {
+        // Given
+        val successTask = Tasks.forResult(null as com.google.firebase.auth.AuthResult?)
+        `when`(mockAuth.signInAnonymously()).thenReturn(successTask)
+
+        // When
+        repository.login()
+
+        // Then
+        verify(mockAuth).signInAnonymously()
+    }
+}

--- a/app/src/test/java/com/shunk0616/gpshealthconnect/ui/authentication/AuthenticationViewModelTest.kt
+++ b/app/src/test/java/com/shunk0616/gpshealthconnect/ui/authentication/AuthenticationViewModelTest.kt
@@ -1,0 +1,65 @@
+package com.shunk0616.gpshealthconnect.ui.authentication
+
+import com.shunk0616.gpshealthconnect.data.repository.AccountRepository
+import com.shunk0616.gpshealthconnect.data.repository.LogRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+
+@ExperimentalCoroutinesApi
+class AuthenticationViewModelTest {
+
+    @Mock
+    private lateinit var accountRepository: AccountRepository
+
+    @Mock
+    private lateinit var logRepository: LogRepository
+
+    private lateinit var viewModel: AuthenticationViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.openMocks(this)
+        Dispatchers.setMain(testDispatcher)
+        viewModel = AuthenticationViewModel(accountRepository, logRepository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun onSignInClick_callsLoginAndCallback() = runTest {
+        // Given
+        var callbackInvoked = false
+        val callback = { callbackInvoked = true }
+
+        // When
+        viewModel.onSignInClick(callback)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Then
+        verify(accountRepository).login()
+        assert(callbackInvoked)
+    }
+
+    @Test
+    fun initialState_hasNoErrorMessage() {
+        // 初期化時にはエラーメッセージは出ない
+        assert(viewModel.errorMessage == null)
+        verifyNoInteractions(accountRepository)
+        verifyNoInteractions(logRepository)
+    }
+}


### PR DESCRIPTION
# 実装内容
- mockitoを依存関係に追加
- 以下のクラスにunit testsを実装
  - `AccountRepository`
  - `AuthenticationViewModel` 
  - `AuthenticationScreen`

# 目的
- 今後はテストとCIを用いて安全に作業を進めるため